### PR TITLE
Make build.sh Idempotent

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Build
-      run: WITH_DEBUG=true ./build.sh
+      run: WITH_DEBUG=1 ./build.sh
     - name: Download tag
       uses: actions/download-artifact@v1
       with:

--- a/.github/workflows/canaries.yaml
+++ b/.github/workflows/canaries.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Build
-      run: WITH_LATEST_MMTK_CORE=true ./build.sh
+      run: WITH_LATEST_MMTK_CORE=1 ./build.sh
 
   with_upstream_ruby:
     name: Build with with upstream Ruby
@@ -23,4 +23,4 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Build
-      run: WITH_UPSTREAM_RUBY=true ./build.sh
+      run: WITH_UPSTREAM_RUBY=1 ./build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+mmtk-core
+mmtk-ruby
+ruby

--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,6 @@ FROM ubuntu
 ADD . /ruby-mmtk-builder
 WORKDIR /ruby-mmtk-builder
 
-RUN apt update && \
-    apt install -y curl git build-essential sudo ruby
+RUN apt update
+RUN apt install -y curl git build-essential sudo ruby
 RUN ./build.sh

--- a/Containerfile
+++ b/Containerfile
@@ -3,5 +3,6 @@ ADD . /ruby-mmtk-builder
 WORKDIR /ruby-mmtk-builder
 
 RUN apt update
-RUN apt install -y curl git build-essential sudo ruby
-RUN ./build.sh
+RUN apt install -y curl git sudo ruby autoconf bison gcc make zlib1g-dev \
+    libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
+RUN WITH_DEBUG=1 ./build.sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Within this directory.
 
 The following environment variables can be used
 
-`WITH_LATEST_MMTK_CORE=yes` to use latest MMTk (may not work.)
+`WITH_LATEST_MMTK_CORE=1` to use latest MMTk (may not work.)
 
 `WITH_UPSTREAM_RUBY=yes` to merge with upstream Ruby (may not work.)
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The following environment variables can be used
 
 `WITH_LATEST_MMTK_CORE=1` to use latest MMTk (may not work.)
 
-`WITH_UPSTREAM_RUBY=yes` to merge with upstream Ruby (may not work.)
+`WITH_UPSTREAM_RUBY=1` to merge with upstream Ruby (may not work.)
 
-`WITH_DEBUG=yes` to build a debug version.
+`WITH_DEBUG=1` to build a debug version.
 
 ## Building a Ruby release
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,11 @@
 
 set -euxo pipefail
 
+build_root=$(pwd)
+mmtk_core_location=$build_root/mmtk-core
+
 default_rust_toolchain=${RUSTUP_TOOLCHAIN:-stable}
+mmtk_core_use_latest=${WITH_LATEST_MMTK_CORE:-0}
 
 function install_rust {
     [[ $# -lt 1 ]] && exit 1
@@ -14,18 +18,26 @@ function install_rust {
     rustup toolchain install $1
 }
 
+function setup_mmtk_core {
+    [[ $# -lt 2 ]] && exit 1
+
+    git clone https://github.com/mmtk/mmtk-core $1
+
+    if [[ $2 -gt 0 ]]; then
+        pushd $1
+        # TODO: Find out what the status of this branch is
+        git remote add wks https://github.com/wks/mmtk-core &&
+            git fetch wks &&
+            git checkout wks/ruby-friendly-tracing
+        popd
+    fi
+}
+
 install_rust $default_rust_toolchain
 
-WITH_LATEST_MMTK_CORE=yes # always using latest at the moment
+[[ ! -d $mmtk_core_location ]] &&
+    setup_mmtk_core $mmtk_core_location $mmtk_core_use_latest
 
-git clone https://github.com/mmtk/mmtk-core
-pushd mmtk-core
-if [ ! -v WITH_LATEST_MMTK_CORE ]
-then
-  git remote add wks https://github.com/wks/mmtk-core
-  git checkout wks/ruby-friendly-tracing
-fi
-popd
 
 git clone https://github.com/mmtk/mmtk-ruby
 pushd mmtk-ruby/mmtk

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ then
 else
   CONFIGURE_FLAGS=
 fi
-./configure --with-mmtk-ruby=../mmtk-ruby --prefix=$PWD/build $CONFIGURE_FLAGS
+./configure --disable-install-doc --with-mmtk-ruby=../mmtk-ruby --prefix=$PWD/build $CONFIGURE_FLAGS
 make
 make install
 popd

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ function install_rust {
 function setup_mmtk_core {
     [[ $# -lt 2 ]] && exit 1
 
-    git clone https://github.com/mmtk/mmtk-core $1
+    git clone --depth=1 https://github.com/mmtk/mmtk-core $1
 
     if [[ $2 -gt 0 ]]; then
         pushd $1
@@ -41,7 +41,7 @@ function setup_mmtk_core {
 function setup_mmtk_ruby {
     [[ $# -lt 1 ]] && exit
 
-    git clone https://github.com/mmtk/mmtk-ruby $1
+    git clone --depth=1 https://github.com/mmtk/mmtk-ruby $1
 }
 
 function build_mmtk_ruby {
@@ -65,7 +65,7 @@ function build_mmtk_ruby {
 function setup_ruby {
     [[ $# -lt 2 ]] && exit 1
 
-    git clone https://github.com/mmtk/ruby $1
+    git clone --depth=1 https://github.com/mmtk/ruby $1
 
     pushd $1
     if [[ $2 -gt 0 ]]; then

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,19 @@
 
 set -euxo pipefail
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
-source $HOME/.cargo/env
+default_rust_toolchain=${RUSTUP_TOOLCHAIN:-stable}
+
+function install_rust {
+    [[ $# -lt 1 ]] && exit 1
+
+    if [[ ! -d $HOME/.cargo ]]; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+        source $HOME/.cargo/env
+    fi
+    rustup toolchain install $1
+}
+
+install_rust $default_rust_toolchain
 
 WITH_LATEST_MMTK_CORE=yes # always using latest at the moment
 
@@ -15,9 +26,6 @@ then
   git checkout wks/ruby-friendly-tracing
 fi
 popd
-
-export RUSTUP_TOOLCHAIN=stable # $(cat mmtk-core/rust-toolchain)
-rustup toolchain install $RUSTUP_TOOLCHAIN
 
 git clone https://github.com/mmtk/mmtk-ruby
 pushd mmtk-ruby/mmtk


### PR DESCRIPTION
This PR refactors build.sh. It uses bash functions to make the individual parts easier to reason about, and it introduces checks that allow the script to be run multiple times for eventual consistency.

Previously errors were unrecoverable, and required manual cleanup of intermediate build artifacts before the script could be re-run