### PR TITLE
Also run tests with Immix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,13 @@ jobs:
     #   run: make -C ruby btest RUN_OPTS=--mmtk-plan=NoGC
     - name: Bootstrap test +MMTk(MarkSweep)
       run: make -C ruby btest RUN_OPTS=--mmtk-plan=MarkSweep
+    - name: Bootstrap test +MMTk(Immix)
+      run: make -C ruby btest RUN_OPTS=--mmtk-plan=Immix
     # - name: MMTk test +MMTk(NoGC)
     #   run: make -C ruby test-all TESTS='test/ruby/test_mmtk.rb' RUN_OPTS="--mmtk-plan=NoGC" TESTOPTS=-v
-    - name: MMTk test +MMTk(MarkSweep)
-      run: make -C ruby test-all TESTS='test/ruby/test_mmtk.rb' RUN_OPTS="--mmtk-plan=MarkSweep" TESTOPTS=-v
+    - name: MMTk test +MMTk(default plan)
+      run: make -C ruby test-all TESTS='test/ruby/test_mmtk.rb' RUN_OPTS="--mmtk" TESTOPTS=-v
     - name: Test +MMTk(MarkSweep)
       run: make -C ruby test-all TESTS=$(cat mmtk_tests.txt | ruby -e 'puts ARGF.map(&:strip).reject { |line| line.start_with?("#") }.join(" ")') RUN_OPTS="--mmtk-plan=MarkSweep" TESTOPTS=-v
+    - name: Test +MMTk(Immix)
+      run: make -C ruby test-all TESTS=$(cat mmtk_tests.txt | ruby -e 'puts ARGF.map(&:strip).reject { |line| line.start_with?("#") }.join(" ")') RUN_OPTS="--mmtk-plan=Immix" TESTOPTS=-v


### PR DESCRIPTION
Now both MarkSweep and Immix are supported.  We can run tests with both plans.  The focus of `test-mmtk.rb` is command line options and MMTk-specific run-time features.  We can use the default plan (which is currently MarkSweep, but is subject to change) instead of hard-coding MarkSweep.

Some of the test-all tests still fail.  Nevertheless, we can enable Immix for it, too, to reveal more problems.